### PR TITLE
preserve metadata in source layer

### DIFF
--- a/src/adc/_projection_stack.py
+++ b/src/adc/_projection_stack.py
@@ -59,7 +59,7 @@ class ProjectAlong(QWidget):
         letter, size = axis_sel.split(":")
         self.total = int(size)
         axis = self.axis_selector.choices.index(axis_sel)
-        self.meta = self.dataset.metadata
+        self.meta = self.dataset.metadata.copy()
 
         selected_op = self.op_widget.current_choice
 

--- a/src/adc/tests/test_stack.py
+++ b/src/adc/tests/test_stack.py
@@ -13,6 +13,7 @@ import logging
 from adc._projection_stack import ProjectAlong
 from adc._split_stack import SplitAlong
 from adc._sub_stack import SubStack
+from adc._reader import napari_get_reader
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -88,3 +89,12 @@ def test_substack(test_stack):
         raise e
     finally:
         shutil.rmtree(testdir)
+
+def test_project(make_napari_viewer, test_stack):
+    v = make_napari_viewer()
+    v.add_image(**test_stack)
+    m = v.layers[0].metadata.copy()
+    p = ProjectAlong(v)
+    p.axis_selector.value = "Z:15"
+    p.make_projection()
+    assert v.layers[0].metadata == m

--- a/src/adc/tests/test_stack.py
+++ b/src/adc/tests/test_stack.py
@@ -33,8 +33,8 @@ def test_stack():
     }
 
 
-def test_substack(test_stack):
-    v = napari.Viewer()
+def test_substack(make_napari_viewer, test_stack):
+    v = make_napari_viewer()
     v.add_image(**test_stack)
     assert len(v.layers) == 3
 


### PR DESCRIPTION
Because no dict copy was used, the source metadata was overidden